### PR TITLE
Add logs api endpoints

### DIFF
--- a/controller/streamlog.go
+++ b/controller/streamlog.go
@@ -1,0 +1,52 @@
+package controller
+
+import (
+	"errors"
+	"github.com/NubeIO/rubix-edge/pkg/streamlog"
+	"github.com/gin-gonic/gin"
+)
+
+func getBodyLogStreamCreate(c *gin.Context) (dto *streamlog.Log, err error) {
+	err = c.ShouldBindJSON(&dto)
+	return dto, err
+}
+
+func (inst *Controller) GetStreamLogs(c *gin.Context) {
+	logStreams := streamlog.GetStreamsLogs()
+	reposeHandler(logStreams, nil, c)
+}
+
+func (inst *Controller) GetStreamLog(c *gin.Context) {
+	u := c.Param("uuid")
+	logStream := streamlog.GetStreamLog(u)
+	if logStream == nil {
+		reposeHandler(nil, errors.New("log not found"), c)
+		return
+	}
+	reposeHandler(logStream, nil, c)
+}
+
+func (inst *Controller) CreateStreamLog(c *gin.Context) {
+	body, err := getBodyLogStreamCreate(c)
+	if err != nil {
+		reposeHandler(nil, err, c)
+		return
+	}
+	uuid := streamlog.CreateStreamLog(body)
+	reposeHandler(map[string]interface{}{"UUID": uuid}, err, c)
+}
+
+func (inst *Controller) DeleteStreamLog(c *gin.Context) {
+	u := c.Param("uuid")
+	deleted := streamlog.DeleteStreamLog(u)
+	if !deleted {
+		reposeHandler(nil, errors.New("log not found"), c)
+		return
+	}
+	reposeHandler(deleted, nil, c)
+}
+
+func (inst *Controller) DeleteStreamLogs(c *gin.Context) {
+	streamlog.DeleteStreamLogs()
+	reposeHandler(true, nil, c)
+}

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,10 @@ require (
 	gorm.io/gorm v1.23.5
 )
 
-require github.com/NubeIO/lib-dirs v0.0.1 // indirect
+require (
+	github.com/NubeIO/lib-dirs v0.0.1 // indirect
+	github.com/NubeIO/lib-journalctl v0.0.0-20220830013922-d7ec41cce123 // indirect
+)
 
 require (
 	github.com/NubeIO/lib-uuid v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/NubeIO/lib-dirs v0.0.1 h1:4YWJbNWniiHyO7Fn1d4MIPuiNlkj7taGn/F0Zfp6Swk
 github.com/NubeIO/lib-dirs v0.0.1/go.mod h1:PCDWQm82Nezp9oyhkpqyfVH6w6+1lzfDwfRdYVF5sPY=
 github.com/NubeIO/lib-files v0.1.1 h1:sgqQ78VpFhbagawKCQglw0Y9o2Vww/c8nFPefDPFYfA=
 github.com/NubeIO/lib-files v0.1.1/go.mod h1:xi4mqMscDl6319i10LFowq5QvwChJLjqHCIJGkGa4RI=
+github.com/NubeIO/lib-journalctl v0.0.0-20220830013922-d7ec41cce123 h1:s4SKXT2ID6HsHxHE3ODC7PLJkSjViZNpLhINSfsnGsU=
+github.com/NubeIO/lib-journalctl v0.0.0-20220830013922-d7ec41cce123/go.mod h1:sh1uH1qyEB5lwIg1ZvrcQ9bZzK3/EAaKs059jDA5RnU=
 github.com/NubeIO/lib-networking v0.0.6/go.mod h1:wO04Ul6Wdr5w/7s8UMZzV1/HMXuVSVFzqq7h5A3Vl6k=
 github.com/NubeIO/lib-networking v0.0.7 h1:8aN4gLs2SORtFanr0NuQ0n22HEY3KbGiMuAWV4daKr4=
 github.com/NubeIO/lib-networking v0.0.7/go.mod h1:wO04Ul6Wdr5w/7s8UMZzV1/HMXuVSVFzqq7h5A3Vl6k=

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -220,5 +220,14 @@ func Setup(db *gorm.DB) *gin.Engine {
 		token.DELETE("/:uuid", api.DeleteToken)
 	}
 
+	streamLog := apiRoutes.Group("/logs")
+	{
+		streamLog.GET("", api.GetStreamLogs)
+		streamLog.GET("/:uuid", api.GetStreamLog)
+		streamLog.POST("", api.CreateStreamLog)
+		streamLog.DELETE("/:uuid", api.DeleteStreamLog)
+		streamLog.DELETE("", api.DeleteStreamLogs)
+	}
+
 	return engine
 }

--- a/pkg/streamlog/streamlog.go
+++ b/pkg/streamlog/streamlog.go
@@ -1,0 +1,67 @@
+package streamlog
+
+import (
+	"fmt"
+	"github.com/NubeIO/lib-journalctl/journalctl"
+	"github.com/google/uuid"
+	"time"
+)
+
+var Logs []*Log
+
+type Log struct {
+	UUID     string   `json:"uuid"`
+	Service  string   `json:"service" binding:"required"`
+	Duration int      `json:"duration" binding:"required"`
+	Message  []string `json:"message"`
+}
+
+func GetStreamsLogs() []*Log {
+	if Logs == nil {
+		Logs = []*Log{}
+	}
+	return Logs
+}
+
+func GetStreamLog(uuid string) *Log {
+	for _, log := range Logs {
+		if log.UUID == uuid {
+			return log
+		}
+	}
+	return nil
+}
+
+func CreateStreamLog(body *Log) string {
+	body.UUID = fmt.Sprintf("log_%s", uuid.New().String())
+	body.Message = []string{}
+	go createLogStream(body)
+	return body.UUID
+}
+
+func DeleteStreamLog(uuid string) bool {
+	deleted := false
+	for i, entry := range Logs {
+		if entry.UUID == uuid {
+			Logs = append(Logs[:i], Logs[i+1:]...)
+			deleted = true
+			break
+		}
+	}
+	return deleted
+}
+
+func DeleteStreamLogs() {
+	Logs = []*Log{}
+}
+
+func createLogStream(body *Log) {
+	time.Sleep(time.Duration(body.Duration) * time.Second)
+	entries, err := journalctl.NewJournalCTL().EntriesAfter(body.Service, "", "")
+	for _, entry := range entries {
+		body.Message = append(body.Message, entry.Message)
+	}
+	if err == nil {
+		Logs = append(Logs, body)
+	}
+}


### PR DESCRIPTION
Resolves: #29 
### Summary:
- Added `api/logs` api endpoints. Examples
  - GET `api/logs` & `api/logs/<uuid>`
  - POST `api/logs` 
     ```
       -d
       {
          "service":"nubeio-flow-framework.service",
          "duration":60
       }
    ```
  - DELETE `api/logs` & `api/logs/<uuid>`
