### PR TITLE
Release/0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [v0.3.1](https://github.com/NubeIO/rubix-edge/tree/v0.3.1) (2022-10-16)
+
+- Upgrade lib-rubix-installer to version v0.3.1 to fix wires installation
+
 ## [v0.3.0](https://github.com/NubeIO/rubix-edge/tree/v0.3.0) (2022-09-22)
 
 - Lots of improvements

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/NubeIO/lib-files v0.1.1
 	github.com/NubeIO/lib-journalctl v0.0.0-20220830013922-d7ec41cce123
 	github.com/NubeIO/lib-networking v0.0.7
-	github.com/NubeIO/lib-rubix-installer v0.3.0
+	github.com/NubeIO/lib-rubix-installer v0.3.1
 	github.com/NubeIO/lib-ufw v0.0.3
 	github.com/NubeIO/nubeio-rubix-lib-auth-go v1.0.3
 	github.com/NubeIO/nubeio-rubix-lib-helpers-go v0.2.7

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/NubeIO/lib-journalctl v0.0.0-20220830013922-d7ec41cce123 h1:s4SKXT2ID
 github.com/NubeIO/lib-journalctl v0.0.0-20220830013922-d7ec41cce123/go.mod h1:sh1uH1qyEB5lwIg1ZvrcQ9bZzK3/EAaKs059jDA5RnU=
 github.com/NubeIO/lib-networking v0.0.7 h1:8aN4gLs2SORtFanr0NuQ0n22HEY3KbGiMuAWV4daKr4=
 github.com/NubeIO/lib-networking v0.0.7/go.mod h1:wO04Ul6Wdr5w/7s8UMZzV1/HMXuVSVFzqq7h5A3Vl6k=
-github.com/NubeIO/lib-rubix-installer v0.3.0 h1:ovttVQhVSDNd/ZxydUP4tbf8yCQJJoa/kTD9KoBiQa4=
-github.com/NubeIO/lib-rubix-installer v0.3.0/go.mod h1:Ibvs0eGhYD77xp+qkPoAP1RSxos+JONHm3tXJ08S2kA=
+github.com/NubeIO/lib-rubix-installer v0.3.1 h1:tZXdqGs8HXQr9pb6UE8/f/TsGv3T5PRdQj7NuTyCgIw=
+github.com/NubeIO/lib-rubix-installer v0.3.1/go.mod h1:Ibvs0eGhYD77xp+qkPoAP1RSxos+JONHm3tXJ08S2kA=
 github.com/NubeIO/lib-systemctl-go v0.2.0 h1:Ch4UmA8LH+YoNVM02tfmb3olCyjmo+qKc7wCtxbq/aM=
 github.com/NubeIO/lib-systemctl-go v0.2.0/go.mod h1:P/Ij5pgTtjNnp/TQhsvwipk8sv+5cbZdtuvHiPAYXCE=
 github.com/NubeIO/lib-ufw v0.0.3 h1:dHzhUFyG6AJ9g+iQ18cYJNU6qO5Ad6dAaXKIRoGDa28=


### PR DESCRIPTION
### Summary

- Upgrade lib-rubix-installer to version v0.3.1 to fix wires installation