### PR TITLE
Bump version (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
-## [v0.3.1](https://github.com/NubeIO/rubix-edge/tree/v0.3.2) (2022-10-26)
+## [v0.5.0](https://github.com/NubeIO/rubix-edge/tree/v0.5.0) (2022-11-24)
+
+- Upgrade files, dirs, zip, systemctl, syscall APIs
+- Remove lib-rubix-installer and upgrade lib-files
+- Upgrade rubix-registry-go for device_type field
+- Remove unused APIs
+
+## [v0.4.0](https://github.com/NubeIO/rubix-edge/tree/v0.4.0) (2022-11-13)
 
 - Add auth handler back
 


### PR DESCRIPTION
### Includes

- Upgrade files, dirs, zip, systemctl, syscall APIs
- Remove lib-rubix-installer and upgrade lib-files
- Upgrade rubix-registry-go for device_type field
- Remove unused APIs