### PR TITLE
Release/0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [v0.5.5](https://github.com/NubeIO/rubix-edge/tree/v0.5.5) (2022-01-25)
+
+- Protect `/api/system/device` API by Auth
+    - we use this API to ping and render the device status
+- Fix: logs APIs
+
 ## [v0.5.4](https://github.com/NubeIO/rubix-edge/tree/v0.5.4) (2022-01-14)
 
 - Fix: sudo: executable file not found in $PATH

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -64,7 +64,6 @@ func Setup() *gin.Engine {
 	publicSystemApi := engine.Group("/api/system")
 	{
 		publicSystemApi.GET("/ping", api.Ping)
-		publicSystemApi.GET("/device", api.GetDeviceInfo)
 		publicSystemApi.GET("/network_interfaces", api.GetNetworkInterfaces)
 		publicSystemApi.POST("/reboot", api.RebootHost)
 	}
@@ -125,6 +124,7 @@ func Setup() *gin.Engine {
 
 	systemApi := apiRoutes.Group("/system")
 	{
+		systemApi.GET("/device", api.GetDeviceInfo)
 		systemApi.PATCH("/device", api.UpdateDeviceInfo)
 		systemApi.POST("/scanner", api.RunScanner)
 	}


### PR DESCRIPTION
### Summary

- Protect `/api/system/device` API by Auth
    - we use this API to ping and render the device status
- Fix: logs APIs