### PR TITLE
Add create and restore snapshots api endpoint

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -23,6 +23,9 @@ func runServer(cmd *cobra.Command, args []string) {
 	if err := os.MkdirAll(config.Config.GetAbsDataDir(), 0755); err != nil {
 		panic(err)
 	}
+	if err := os.MkdirAll(config.Config.GetAbsTempDir(), 0755); err != nil {
+		panic(err)
+	}
 	logger.Init()
 	logger.Logger.Infoln("starting edge...")
 

--- a/controller/snapshot.go
+++ b/controller/snapshot.go
@@ -140,6 +140,12 @@ func (inst *Controller) RestoreSnapshot(c *gin.Context) {
 		inst.updateDeviceInfo()
 	}
 	if copySystemFiles {
+		err = inst.SystemCtl.DaemonReload()
+		if err != nil {
+			restoreStatus = model.RestoreFailed
+			responseHandler(nil, err, c)
+			return
+		}
 		inst.enableAndRestartServices(services)
 	}
 	message := model.Message{Message: "snapshot is restored successfully"}

--- a/controller/snapshot.go
+++ b/controller/snapshot.go
@@ -1,0 +1,172 @@
+package controller
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/NubeIO/lib-files/fileutils"
+	"github.com/NubeIO/rubix-edge/model"
+	"github.com/NubeIO/rubix-edge/pkg/config"
+	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+var systemPath = "/lib/systemd/system"
+var dataFolder = "data"
+var systemFolder = "system"
+var createStatus = "N/A"
+var restoreStatus = "N/A"
+
+func (inst *Controller) Create(c *gin.Context) {
+	if createStatus == "Running" {
+		responseHandler(nil, errors.New("create snapshot is running"), c)
+		return
+	}
+	createStatus = "Running"
+	deviceInfo, err := inst.RubixRegistry.GetDeviceInfo()
+	if err != nil {
+		createStatus = "Failed"
+		responseHandler(nil, err, c)
+		return
+	}
+	destinationPath := fmt.Sprintf("%s/%s-%s-%s_%s", config.Config.GetAbsTempDir(), deviceInfo.ClientName,
+		deviceInfo.SiteName, deviceInfo.DeviceName, time.Now().UTC().Format("20060102T150405"))
+	_ = copyFolder(config.Config.GetAbsDataDir(), path.Join(destinationPath, dataFolder))
+
+	systemFiles, err := filepath.Glob(path.Join(systemPath, "nubeio-*"))
+	if err != nil {
+		createStatus = "Failed"
+		responseHandler(nil, err, c)
+		return
+	}
+	copyFiles(systemFiles, path.Join(destinationPath, systemFolder))
+
+	zipDestinationPath := destinationPath + ".zip"
+	err = fileutils.RecursiveZip(destinationPath, zipDestinationPath)
+	if err != nil {
+		createStatus = "Failed"
+		responseHandler(nil, err, c)
+		return
+	}
+	err = checkSnapshotSize(zipDestinationPath)
+	if err != nil {
+		createStatus = "Failed"
+		responseHandler(nil, err, c)
+		return
+	}
+	createStatus = "Created"
+	c.FileAttachment(zipDestinationPath, filepath.Base(zipDestinationPath))
+}
+
+func (inst *Controller) Restore(c *gin.Context) {
+	if restoreStatus == "Running" {
+		responseHandler(nil, errors.New("restore snapshot is running"), c)
+		return
+	}
+	restoreStatus = "Running"
+	useGlobalUUID, _ := toBool(c.Query("use_global_uuid"))
+	file, _ := c.FormFile("file")
+	destinationFilePath := path.Join(config.Config.GetAbsTempDir(), file.Filename)
+	err := c.SaveUploadedFile(file, destinationFilePath)
+	if err != nil {
+		restoreStatus = err.Error()
+		responseHandler(nil, err, c)
+		return
+	}
+	_, err = fileutils.Unzip(destinationFilePath, path.Join(config.Config.GetAbsTempDir(), ""), os.FileMode(inst.FileMode))
+	if err != nil {
+		restoreStatus = err.Error()
+		responseHandler(nil, err, c)
+		return
+	}
+	unzippedFolderPath := path.Join(config.Config.GetAbsTempDir(), fileNameWithoutExtension(file.Filename))
+	services, _ := fileutils.ListFiles(path.Join(unzippedFolderPath, systemFolder))
+	inst.stopServices(services)
+	err = copyFolder(path.Join(unzippedFolderPath, systemFolder), systemPath)
+	if err != nil {
+		restoreStatus = err.Error()
+		responseHandler(nil, err, c)
+		return
+	}
+	err = copyFolder(path.Join(unzippedFolderPath, dataFolder), config.Config.GetAbsDataDir())
+	if err != nil {
+		restoreStatus = err.Error()
+		responseHandler(nil, err, c)
+		return
+	}
+	if !useGlobalUUID {
+		inst.updateDeviceInfo()
+	}
+	inst.enableAndRestartServices(services)
+	message := model.Message{Message: "snapshot restored successfully"}
+	restoreStatus = "Restored"
+	responseHandler(message, err, c)
+}
+
+func (inst *Controller) Status(c *gin.Context) {
+	responseHandler(model.SnapshotStatus{Create: createStatus, Restore: restoreStatus}, nil, c)
+}
+
+func (inst *Controller) stopServices(services []string) {
+	var wg sync.WaitGroup
+	for _, service := range services {
+		wg.Add(1)
+		service := service
+		go func() {
+			defer wg.Done()
+			if !strings.Contains(service, "rubix-edge") {
+				err := inst.SystemCtl.Stop(service)
+				if err != nil {
+					log.Errorf("err: %s", err.Error())
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func (inst *Controller) enableAndRestartServices(services []string) {
+	var wg sync.WaitGroup
+	for _, service := range services {
+		wg.Add(1)
+		service := service
+		go func() {
+			defer wg.Done()
+			if !strings.Contains(service, "rubix-edge") {
+				err := inst.SystemCtl.Enable(service)
+				if err != nil {
+					log.Errorf("err: %s", err.Error())
+				}
+				err = inst.SystemCtl.Restart(service)
+				if err != nil {
+					log.Errorf("err: %s", err.Error())
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func (inst *Controller) updateDeviceInfo() {
+	deviceInfo, err := inst.RubixRegistry.GetDeviceInfo()
+	if err != nil {
+		log.Errorf("err: %s", err.Error())
+	} else {
+		deviceInfo.GlobalUUID = ""
+		deviceInfoDefaultRaw, err := json.Marshal(deviceInfo)
+		if err != nil {
+			log.Errorf("err: %s", err.Error())
+		}
+		err = os.WriteFile(path.Join("/", config.Config.GetAbsDataDir(), "rubix-registry/device_info.json"),
+			deviceInfoDefaultRaw, os.FileMode(inst.FileMode))
+		if err != nil {
+			log.Errorf("err: %s", err.Error())
+		}
+	}
+}

--- a/controller/snapshot.go
+++ b/controller/snapshot.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 )
@@ -161,16 +160,15 @@ func (inst *Controller) stopServices(services []string) {
 	var wg sync.WaitGroup
 	for _, service := range services {
 		wg.Add(1)
-		service := service
-		go func() {
+		go func(service string) {
 			defer wg.Done()
-			if !strings.Contains(service, "rubix-edge") {
+			if service != "nubeio-rubix-edge.service" {
 				err := inst.SystemCtl.Stop(service)
 				if err != nil {
 					log.Errorf("err: %s", err.Error())
 				}
 			}
-		}()
+		}(service)
 	}
 	wg.Wait()
 }
@@ -179,10 +177,9 @@ func (inst *Controller) enableAndRestartServices(services []string) {
 	var wg sync.WaitGroup
 	for _, service := range services {
 		wg.Add(1)
-		service := service
-		go func() {
+		go func(service string) {
 			defer wg.Done()
-			if !strings.Contains(service, "rubix-edge") {
+			if service != "nubeio-rubix-edge.service" {
 				err := inst.SystemCtl.Enable(service)
 				if err != nil {
 					log.Errorf("err: %s", err.Error())
@@ -192,7 +189,7 @@ func (inst *Controller) enableAndRestartServices(services []string) {
 					log.Errorf("err: %s", err.Error())
 				}
 			}
-		}()
+		}(service)
 	}
 	wg.Wait()
 }

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -1,0 +1,119 @@
+package controller
+
+import (
+	"errors"
+	"github.com/NubeIO/lib-files/fileutils"
+	"github.com/NubeIO/nubeio-rubix-lib-helpers-go/pkg/bools"
+	log "github.com/sirupsen/logrus"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+func fileNameWithoutExtension(fileName string) string {
+	return strings.TrimSuffix(fileName, filepath.Ext(fileName))
+}
+
+func toBool(value string) (bool, error) {
+	if value == "" {
+		return false, nil
+	} else {
+		c, err := bools.Boolean(value)
+		return c, err
+	}
+}
+
+func resolve(name string) string {
+	if filepath.Separator != '/' && strings.ContainsRune(name, filepath.Separator) ||
+		strings.Contains(name, "\x00") {
+		return ""
+	}
+	return filepath.FromSlash(fileutils.SlashClean(name))
+}
+
+func copyFolder(source string, dest string) error {
+	if source = resolve(source); source == "" {
+		return os.ErrNotExist
+	}
+	if dest = resolve(dest); dest == "" {
+		return os.ErrNotExist
+	}
+	srcinfo, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(dest, srcinfo.Mode())
+	if err != nil {
+		return err
+	}
+	dir, _ := os.Open(source)
+	obs, err := dir.Readdir(-1)
+	if err != nil {
+		return err
+	}
+	var wg sync.WaitGroup
+	var errs []error
+	for _, obj := range obs {
+		wg.Add(1)
+		obj := obj
+		go func() {
+			defer wg.Done()
+			fsource := source + "/" + obj.Name()
+			fdest := dest + "/" + obj.Name()
+
+			if obj.IsDir() {
+				if obj.Name() != "rubix-edge" {
+					err = copyFolder(fsource, fdest)
+					if err != nil {
+						errs = append(errs, err)
+					}
+				}
+			} else {
+				err = fileutils.CopyFile(fsource, fdest)
+				if err != nil {
+					errs = append(errs, err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	var errString string
+	for _, err := range errs {
+		errString += err.Error() + "\n"
+	}
+	if errString != "" {
+		return errors.New(errString)
+	}
+	return nil
+}
+
+func copyFiles(srcFiles []string, dest string) {
+	var wg sync.WaitGroup
+	for _, srcFile := range srcFiles {
+		wg.Add(1)
+		srcFile := srcFile
+		go func() {
+			defer wg.Done()
+			if !strings.Contains(srcFile, "rubix-edge") {
+				err := fileutils.CopyFile(srcFile, path.Join(dest, filepath.Base(srcFile)))
+				if err != nil {
+					log.Errorf("err: %s", err.Error())
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func checkSnapshotSize(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.Size()/1024/1024/1024 > 1 {
+		return errors.New("maximum response size reached")
+	}
+	return nil
+}

--- a/model/status.go
+++ b/model/status.go
@@ -17,7 +17,25 @@ type SystemCtlStateStatus struct {
 	Status string `json:"status"`
 }
 
+type CreateStatus string
+
+const (
+	CreateNotAvailable CreateStatus = "N/A"
+	Creating           CreateStatus = "Creating"
+	Created            CreateStatus = "Created"
+	CreateFailed       CreateStatus = "Failed"
+)
+
+type RestoreStatus string
+
+const (
+	RestoreNotAvailable RestoreStatus = "N/A"
+	Restoring           RestoreStatus = "Restoring"
+	Restored            RestoreStatus = "Restored"
+	RestoreFailed       RestoreStatus = "Failed"
+)
+
 type SnapshotStatus struct {
-	Create  string `json:"create"`
-	Restore string `json:"restore"`
+	CreateStatus  CreateStatus  `json:"create_status"`
+	RestoreStatus RestoreStatus `json:"restore_status"`
 }

--- a/model/status.go
+++ b/model/status.go
@@ -16,3 +16,8 @@ type SystemCtlStateStatus struct {
 	State  bool   `json:"state"`
 	Status string `json:"status"`
 }
+
+type SnapshotStatus struct {
+	Create  string `json:"create"`
+	Restore string `json:"restore"`
+}

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -56,6 +56,10 @@ func (conf *Configuration) GetAbsTempDir() string {
 	return "/tmp"
 }
 
+func (conf *Configuration) GetSnapshotDir() string {
+	return "/data"
+}
+
 func (conf *Configuration) getGlobalDir() string {
 	rootDir := RootCmd.PersistentFlags().Lookup("root-dir").Value.String()
 	appDir := RootCmd.PersistentFlags().Lookup("app-dir").Value.String()

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -52,6 +52,10 @@ func (conf *Configuration) GetAbsConfigDir() string {
 	return path.Join(conf.getGlobalDir(), conf.getConfigDir())
 }
 
+func (conf *Configuration) GetAbsTempDir() string {
+	return "/tmp"
+}
+
 func (conf *Configuration) getGlobalDir() string {
 	rootDir := RootCmd.PersistentFlags().Lookup("root-dir").Value.String()
 	appDir := RootCmd.PersistentFlags().Lookup("app-dir").Value.String()

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -221,9 +221,9 @@ func Setup() *gin.Engine {
 
 	device := apiRoutes.Group("/snapshots")
 	{
-		device.POST("create", api.Create)
-		device.POST("restore", api.Restore)
-		device.GET("status", api.Status)
+		device.POST("create", api.CreateSnapshot)
+		device.POST("restore", api.RestoreSnapshot)
+		device.GET("status", api.SnapshotStatus)
 	}
 
 	return engine

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -219,5 +219,12 @@ func Setup() *gin.Engine {
 		streamLog.DELETE("", api.DeleteStreamLogs)
 	}
 
+	device := apiRoutes.Group("/snapshots")
+	{
+		device.POST("create", api.Create)
+		device.POST("restore", api.Restore)
+		device.GET("status", api.Status)
+	}
+
 	return engine
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -78,16 +78,15 @@ func CopyFiles(srcFiles []string, dest string) {
 	var wg sync.WaitGroup
 	for _, srcFile := range srcFiles {
 		wg.Add(1)
-		srcFile := srcFile
-		go func() {
+		go func(srcFile string) {
 			defer wg.Done()
-			if !strings.Contains(srcFile, "rubix-edge") {
+			if srcFile != "nubeio-rubix-edge.service" {
 				err := fileutils.CopyFile(srcFile, path.Join(dest, filepath.Base(srcFile)))
 				if err != nil {
 					log.Errorf("err: %s", err.Error())
 				}
 			}
-		}()
+		}(srcFile)
 	}
 	wg.Wait()
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -26,11 +26,11 @@ func FileNameWithoutExtension(fileName string) string {
 }
 
 func CopyDir(source string, dest string) error {
-	srcinfo, err := os.Stat(source)
+	srcInfo, err := os.Stat(source)
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(dest, srcinfo.Mode())
+	err = os.MkdirAll(dest, srcInfo.Mode())
 	if err != nil {
 		return err
 	}
@@ -46,18 +46,17 @@ func CopyDir(source string, dest string) error {
 		obj := obj
 		go func() {
 			defer wg.Done()
-			fsource := source + "/" + obj.Name()
-			fdest := dest + "/" + obj.Name()
-
+			fSource := path.Join(source, obj.Name())
+			fDest := path.Join(dest, obj.Name())
 			if obj.IsDir() {
-				if obj.Name() != "rubix-edge" {
-					err = CopyDir(fsource, fdest)
+				if obj.Name() != "rubix-edge" && obj.Name() != "tmp" && obj.Name() != "store" && obj.Name() != "backup" {
+					err = CopyDir(fSource, fDest)
 					if err != nil {
 						errs = append(errs, err)
 					}
 				}
 			} else {
-				err = fileutils.CopyFile(fsource, fdest)
+				err = fileutils.CopyFile(fSource, fDest)
 				if err != nil {
 					errs = append(errs, err)
 				}


### PR DESCRIPTION
Resolves: #44 
### Summary:
- Added GET `/api/snapshots/status`
- Added POST `/api/snapshots/create`
- Added POST `/api/snapshots/restore>use_global_uuid=<boolean(default: false)>`  endpoint. Example:
```curl -X POST http://localhost:1661/api/snapshots/restore?use_global_uuid=true -H "Content-Type: multipart/form-data" -F "file=<file>"```